### PR TITLE
prefecturesマイグレーションの修正

### DIFF
--- a/db/migrate/20200213091459_create_prefectures.rb
+++ b/db/migrate/20200213091459_create_prefectures.rb
@@ -1,7 +1,7 @@
 class CreatePrefectures < ActiveRecord::Migration[5.2]
   def change
-    create_table :prefectures(active_hash) do |t|
-      t.string   :prefecture_name, null: false
+    create_table :prefectures do |t|
+      t.string   :prefecture_id, null: false, foreign_key: true
       t.string   :user_id, null: false, foreign_key: true
       t.timestamps
     end


### PR DESCRIPTION
＃WHAT
マイグレーションファイル内のエラー解消のための記述変更

＃WHY
rails db:migrateを実行する際にsyntax errorが発生しているため。