### PR TITLE
ログイン・新規登録サーバーサイド実装

### DIFF
--- a/app/assets/javascripts/addresses.coffee
+++ b/app/assets/javascripts/addresses.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/addresses.coffee
+++ b/app/assets/javascripts/addresses.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/addresses.scss
+++ b/app/assets/stylesheets/addresses.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the addresses controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/user.scss
+++ b/app/assets/stylesheets/user.scss
@@ -1,13 +1,28 @@
 .sign_in {
   background-color: #eee;
   text-align: center;
-  height: 1150px;
+  height: 1210px;
   padding-top: 30px;
     &__inner--header {
       h1 {
         padding-bottom: 10px;
         font-size: 40px;
-        border-bottom: solid 2px rgb(104, 100, 100);
+      }
+    &_process {
+      border-bottom: solid 2px rgb(104, 100, 100);
+      p {
+        display: inline-block;
+        margin-bottom: 20px;
+        width: 8%;
+      }
+      &_red {
+        color: red;
+        font-size: 19px;
+        font-weight: bold;
+      }
+      &_gray {
+        color: gray;
+      }
       }
     }
     &__inner--user_form {
@@ -41,7 +56,7 @@
 
 .btn {
   margin-top: 10px;
-  margin-bottom: 20px;
+  margin-bottom: 40px;
   font-size: 30px;
   height: 50px;
   width: 200px;

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -1,0 +1,10 @@
+class AddressesController < ApplicationController
+
+  def new
+  end
+
+  def create
+  end
+
+
+end

--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -1,4 +1,6 @@
 class MypageController < ApplicationController
   def index
+    user = User.find(params[:id])
+    @nicknmae = user.nickname
   end
 end

--- a/app/helpers/addresses_helper.rb
+++ b/app/helpers/addresses_helper.rb
@@ -1,0 +1,2 @@
+module AddressesHelper
+end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -4,6 +4,12 @@
       = link_to root_path do
         = image_tag "furima-logo.png", size: "140x41", class: 'toppage-header-box__header__contents--furima-logo'
       %h1 新規会員登録
+      .sign_in__inner--header_process
+        %p.sign_in__inner--header_process_red 個人情報登録
+        %p.arrow →→→
+        %p.sign_in__inner--header_process_gray 住所登録
+        %p.arrow → → →
+        %p.sign_in__inner--header_process_gray 登録完了
     .sign_in__inner--user_form
       = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
         .sign_in__inner--user_form
@@ -57,13 +63,13 @@
             %i (英数字7文字以上)
             %p.required 必須
           .field-input
-            = f.password_field :password, autocomplete: "new-password"
+            = f.password_field :password, minlength: "7", autocomplete: "new-password"
         .field
           .field-label-password
             %h6.pass_input パスワード確認
             %p.required 必須
           .field-input
-            = f.password_field :password_confirmation, autocomplete: "new-password"
+            = f.password_field :password_confirmation, minlength: "7", autocomplete: "new-password"
         .actions
           = f.submit "会員登録", class: "btn"
           

--- a/app/views/users/_header.html.haml
+++ b/app/views/users/_header.html.haml
@@ -17,9 +17,15 @@
             =link_to "カテゴリー"
           .header-list__left-lists-menu__brands
             =link_to "ブランド"
-
-        .header-list__right-lists-menu
-          .header-list__right-lists-menu__login
-            =link_to "ログイン", new_user_session_path, class: 'post'
-          .header-list__right-lists-menu__new
-            =link_to "新規会員登録", new_user_registration_path, class: 'post'
+        - if user_signed_in?
+          .header-list__right-lists-menu
+            .header-list__right-lists-menu__login
+              =link_to "ログアウト", destroy_user_session_path, method: :delete
+            .header-list__right-lists-menu__new
+              =link_to "マイページ", mypage_index_path, method: :get
+        - else
+          .header-list__right-lists-menu
+            .header-list__right-lists-menu__login
+              =link_to "ログイン", new_user_session_path, class: 'post'
+            .header-list__right-lists-menu__new
+              =link_to "新規会員登録", new_user_registration_path, class: 'post'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
   root to: 'users#index'
   resources :mypage, only: [:index]
   resources :users, only: [:new]
+  resources :addresses, except: [:index, :show]
 end

--- a/test/controllers/addresses_controller_test.rb
+++ b/test/controllers/addresses_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AddressesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
#what
　新規登録・ログインのサーバーサイドの実装。メールアドレス・パスワード等の登録と動作確認。ログイン前と後でログイン・新規登録→ログアウト・マイページにビューか切り替わるように実装。

#why
　ログイン・新規登録で出品・購入などの利用ができるように個人情報の登録を行なってもらう。